### PR TITLE
[FIX] mirror dont run on the target repo

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,4 +1,3 @@
-
 name: Mirror main branch to repo2
 
 on:
@@ -9,6 +8,8 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+
+    if: github.repository != 'EpitechPGE3-2025/G-DEV-500-MPL-5-1-area-3'
     steps:
       # Checkout the source repo
       - name: Checkout source repo


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration for mirroring the main branch. The main change is the addition of a conditional check to prevent the sync job from running on a specific repository.

* Added an `if` condition to the `sync` job in `.github/workflows/mirror.yml` to skip execution when the repository is `EpitechPGE3-2025/G-DEV-500-MPL-5-1-area-3`.